### PR TITLE
Adding tests for shared Acquia HMAC spec fixtures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.bundle
 Gemfile.lock
-
+vendor

--- a/fixtures/acquia_spec.json
+++ b/fixtures/acquia_spec.json
@@ -1,0 +1,172 @@
+{
+  "version": "0.1",
+  "spec_versions": ["1.0", "2.0"],
+  "fixtures" : {
+    "2.0": [
+      {
+	"input": {
+          "name": "GET 1",
+          "description": "Valid GET request",
+	  "host": "example.acquiapipet.net",
+	  "url": "https://example.acquiapipet.net/v1.0/task-status/133?limit=10",
+          "method": "GET",
+	  "content_body": "",
+	  "content_type": "application/json",
+	  "content_sha": "",
+	  "timestamp": 1432075982,
+	  "realm": "Pipet service",
+	  "id": "efdde334-fe7b-11e4-a322-1697f925ec7b",
+	  "secret": "W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=",
+	  "nonce": "d1954337-5319-4821-8427-115542e08d10",
+	  "signed_headers": [],
+	  "headers" : {}
+        },
+	"expectations": {
+          "authorization_header": "acquia-http-hmac id=\"efdde334-fe7b-11e4-a322-1697f925ec7b\",nonce=\"d1954337-5319-4821-8427-115542e08d10\",realm=\"Pipet%20service\",signature=\"MRlPr/Z1WQY2sMthcaEqETRMw4gPYXlPcTpaLWS2gcc=\",version=\"2.0\"",
+          "signable_message": "GET\nexample.acquiapipet.net\n/v1.0/task-status/133\nlimit=10\nid=efdde334-fe7b-11e4-a322-1697f925ec7b&nonce=d1954337-5319-4821-8427-115542e08d10&realm=Pipet%20service&version=2.0\n1432075982",
+          "message_signature": "MRlPr/Z1WQY2sMthcaEqETRMw4gPYXlPcTpaLWS2gcc=",
+          "response_signature": "M4wYp1MKvDpQtVOnN7LVt9L8or4pKyVLhfUFVJxHemU=",
+          "response_body": "{\"id\": 133, \"status\": \"done\"}"
+        }
+      },
+      {
+	"input": {
+          "name": "GET 2",
+          "description": "Valid GET request",
+	  "host": "example.acquiapipet.net",
+	  "url": "https://example.acquiapipet.net/v1.0/task-status/145?limit=1",
+          "method": "GET",
+	  "content_body": "",
+	  "content_type": "application/json",
+	  "content_sha": "",
+	  "timestamp": 1432075982,
+	  "realm": "Pipet service",
+	  "id": "615d6517-1cea-4aa3-b48e-96d83c16c4dd",
+	  "secret": "TXkgU2VjcmV0IEtleSBUaGF0IGlzIFZlcnkgU2VjdXJl",
+	  "nonce": "24c0c836-4f6c-4ed6-a6b0-e091d75ea19d",
+	  "signed_headers": [],
+	  "headers" : {}
+        },
+	"expectations": {
+          "authorization_header": "acquia-http-hmac id=\"615d6517-1cea-4aa3-b48e-96d83c16c4dd\",nonce=\"24c0c836-4f6c-4ed6-a6b0-e091d75ea19d\",realm=\"Pipet%20service\",signature=\"1Ku5UroiW1knVP6GH4l7Z4IuQSRxZO2gp/e5yhapv1s=\",version=\"2.0\"",
+          "signable_message": "GET\nexample.acquiapipet.net\n/v1.0/task-status/145\nlimit=1\nid=615d6517-1cea-4aa3-b48e-96d83c16c4dd&nonce=24c0c836-4f6c-4ed6-a6b0-e091d75ea19d&realm=Pipet%20service&version=2.0\n1432075982",
+          "message_signature": "1Ku5UroiW1knVP6GH4l7Z4IuQSRxZO2gp/e5yhapv1s=",
+          "response_signature": "C98MEJHnQSNiYCxmI4CxJegO62sGZdzEEiSXgSIoxlo=",
+          "response_body": "{\"id\": 145, \"status\": \"in-progress\"}"
+        }
+      },
+      {
+	"input": {
+          "name": "GET 3",
+          "description": "Valid GET request with signed headers",
+	  "host": "example.pipeline.io",
+	  "url": "https://example.pipeline.io/api/v1/ci/pipelines",
+          "method": "GET",
+	  "content_body": "",
+	  "content_type": "application/json",
+	  "content_sha": "",
+	  "timestamp": 1432075982,
+	  "realm": "CIStore",
+	  "id": "e7fe97fa-a0c8-4a42-ab8e-2c26d52df059",
+	  "secret": "bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==",
+	  "nonce": "a9938d07-d9f0-480c-b007-f1e956bcd027",
+	  "signed_headers": [ "X-Custom-Signer1", "X-Custom-Signer2"],
+	  "headers" : {
+            "X-Custom-Signer1": "custom-1",
+            "X-Custom-Signer2": "custom-2"
+	  }
+        },
+	"expectations": {
+          "authorization_header": "acquia-http-hmac headers=\"X-Custom-Signer1%3BX-Custom-Signer2\",id=\"e7fe97fa-a0c8-4a42-ab8e-2c26d52df059\",nonce=\"a9938d07-d9f0-480c-b007-f1e956bcd027\",realm=\"CIStore\",signature=\"yoHiYvx79ssSDIu3+OldpbFs8RsjrMXgRoM89d5t+zA=\",version=\"2.0\"",
+          "signable_message": "GET\nexample.pipeline.io\n/api/v1/ci/pipelines\n\nid=e7fe97fa-a0c8-4a42-ab8e-2c26d52df059&nonce=a9938d07-d9f0-480c-b007-f1e956bcd027&realm=CIStore&version=2.0\nx-custom-signer1:custom-1\nx-custom-signer2:custom-2\n1432075982",
+          "message_signature": "yoHiYvx79ssSDIu3+OldpbFs8RsjrMXgRoM89d5t+zA=",
+          "response_signature": "cUDFSS5tN5vBBS7orIfUag8jhkaGouBb/o8fstUvTF8=",
+          "response_body": "[{\"pipeline_id\":\"39b5d58d-0a8f-437d-8dd6-4da50dcc87b7\",\"sitename\":\"enterprise-g1:sfwiptravis\",\"name\":\"pipeline.yml\",\"last_job_id\":\"810e4344-1bed-4fd0-a642-1ba17eb996d5\",\"last_branch\":\"validate-yaml\",\"last_requested\":\"2016-03-25T20:26:39.000Z\",\"last_finished\":null,\"last_status\":\"succeeded\",\"last_duration\":null}]"
+        }
+      },
+      {
+	"input": {
+          "name": "POST 1",
+          "description": "Valid POST request",
+	  "host": "example.acquiapipet.net",
+	  "url": "https://example.acquiapipet.net/v1.0/task",
+          "method": "POST",
+	  "content_body": "{\"method\":\"hi.bob\",\"params\":[\"5\",\"4\",\"8\"]}",
+	  "content_type": "application/json",
+	  "content_sha": "6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=",
+	  "timestamp": 1432075982,
+	  "realm": "Pipet service",
+	  "id": "efdde334-fe7b-11e4-a322-1697f925ec7b",
+	  "secret": "W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=",
+	  "nonce": "d1954337-5319-4821-8427-115542e08d10",
+	  "signed_headers": [],
+	  "headers" : {}
+        },
+	"expectations": {
+          "authorization_header": "acquia-http-hmac id=\"efdde334-fe7b-11e4-a322-1697f925ec7b\",nonce=\"d1954337-5319-4821-8427-115542e08d10\",realm=\"Pipet%20service\",signature=\"XDBaXgWFCY3aAgQvXyGXMbw9Vds2WPKJe2yP+1eXQgM=\",version=\"2.0\"",
+          "signable_message": "POST\nexample.acquiapipet.net\n/v1.0/task\n\nid=efdde334-fe7b-11e4-a322-1697f925ec7b&nonce=d1954337-5319-4821-8427-115542e08d10&realm=Pipet%20service&version=2.0\n1432075982\napplication/json\n6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=",
+          "message_signature": "XDBaXgWFCY3aAgQvXyGXMbw9Vds2WPKJe2yP+1eXQgM=",
+          "response_signature": "",
+          "response_body": ""
+        }
+      },
+      {
+	"input": {
+          "name": "POST 2",
+          "description": "Valid POST request with signed headers.",
+	  "host": "example.pipeline.io",
+	  "url": "https://example.pipeline.io/api/v1/ci/pipelines/39b5d58d-0a8f-437d-8dd6-4da50dcc87b7/start",
+          "method": "POST",
+	  "content_body": "{\"cloud_endpoint\":\"https://cloudapi.acquia.com/v1\",\"cloud_user\":\"example@acquia.com\",\"cloud_pass\":\"password\",\"branch\":\"validate\"}",
+	  "content_type": "application/json",
+	  "content_sha": "2YGTI4rcSnOEfd7hRwJzQ2OuJYqAf7jzyIdcBXCGreQ=",
+	  "timestamp": 1449578521,
+	  "realm": "CIStore",
+	  "id": "e7fe97fa-a0c8-4a42-ab8e-2c26d52df059",
+	  "secret": "bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==",
+	  "nonce": "a9938d07-d9f0-480c-b007-f1e956bcd027",
+	  "signed_headers": [ "X-Custom-Signer1", "X-Custom-Signer2"],
+	  "headers" : {
+            "X-Custom-Signer1": "custom-1",
+            "X-Custom-Signer2": "custom-2"
+	  }
+        },
+	"expectations": {
+          "authorization_header": "acquia-http-hmac headers=\"X-Custom-Signer1%3BX-Custom-Signer2\",id=\"e7fe97fa-a0c8-4a42-ab8e-2c26d52df059\",nonce=\"a9938d07-d9f0-480c-b007-f1e956bcd027\",realm=\"CIStore\",signature=\"0duvqeMauat7pTULg3EgcSmBjrorrcRkGKxRDtZEa1c=\",version=\"2.0\"",
+          "signable_message": "POST\nexample.pipeline.io\n/api/v1/ci/pipelines/39b5d58d-0a8f-437d-8dd6-4da50dcc87b7/start\n\nid=e7fe97fa-a0c8-4a42-ab8e-2c26d52df059&nonce=a9938d07-d9f0-480c-b007-f1e956bcd027&realm=CIStore&version=2.0\nx-custom-signer1:custom-1\nx-custom-signer2:custom-2\n1449578521\napplication/json\n2YGTI4rcSnOEfd7hRwJzQ2OuJYqAf7jzyIdcBXCGreQ=",
+          "message_signature": "0duvqeMauat7pTULg3EgcSmBjrorrcRkGKxRDtZEa1c=",
+          "response_signature": "SlOYi3pUZADkzU9wEv7kw3hmxjlEyMqBONFEVd7iDbM=",
+          "response_body": "\"57674bb1-f2ce-4d0f-bfdc-736a78aa027a\""
+        }
+      }
+    ]
+  },
+  "skeletons": {
+    "2.0": {
+      "input": {
+        "name": "",
+        "description": "",
+        "host": "",
+        "url": "",
+        "method": "",
+        "content_body": "",
+        "content_type": "",
+        "content_sha": "",
+        "timestamp": 0,
+        "realm": "",
+        "id": "",
+        "secret": "",
+        "nonce": "",
+        "signed_headers": [],
+        "headers" : {}
+      },
+      "expectations": {
+        "authorization_header": "",
+        "signable_message": "",
+        "message_signature": "",
+        "response_signature": "",
+        "response_body": ""
+      }
+    }
+  }
+}

--- a/lib/acquia-http-hmac.rb
+++ b/lib/acquia-http-hmac.rb
@@ -81,8 +81,9 @@ module Acquia
       def request_authenticated?(args = {})
         return false unless args[:realm] == @realm
         return false unless args[:nonce].match(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/)
-        # Allow up to 900 sec (15 min) of clock skew.
-        return false if (Time.now.to_i - args[:timestamp].to_i).abs > 900
+        # Allow up to 900 sec (15 min) of clock skew by default.
+        allowed_skew = args[:allowed_skew] || 900
+        return false if (Time.now.to_i - args[:timestamp].to_i).abs > allowed_skew
         base_string = prepare_base_string(args)
         signature(base_string) == args[:signature]
       end

--- a/test/acquia_spec_test.rb
+++ b/test/acquia_spec_test.rb
@@ -1,0 +1,58 @@
+require 'minitest/autorun'
+require_relative '../lib/acquia-http-hmac'
+
+class TestAcquiaHmacSpec < Minitest::Test
+
+  def test_fixture
+    fixtures_path = File.join(File.dirname(__FILE__), '../fixtures/acquia_spec.json')
+    fixtures_json = File.read(File.realpath(fixtures_path))
+    fixtures = JSON.parse(fixtures_json)
+
+    fixtures['fixtures']['2.0'].each do |fixture|
+      input = fixture['input']
+      expectations = fixture['expectations']
+      uri = URI(input['url'])
+      signed_headers = {}
+      input['signed_headers'].each do |signed_header|
+        signed_headers[signed_header] = input['headers'][signed_header]
+      end
+      body = input['content_body'].empty? ? nil : input['content_body']
+      body_hash = input['content_sha'].empty? ? nil : input['content_sha']
+      mac = Acquia::HTTPHmac::Auth.new(input['realm'], input['secret'])
+      args = {
+        http_method: input['method'],
+        host: input['host'],
+        id: input['id'],
+        path_info: uri.path,
+        query_string: uri.query,
+        body: body,
+        content_type: input['content_type'],
+        nonce: input['nonce'],
+        timestamp: input['timestamp'],
+        headers: signed_headers,
+        body_hash: body_hash,
+      }
+      headers = mac.prepare_request_headers(args)
+
+      # Prove we can generate the correct Authorization header.
+      expected_realm = URI::encode(input['realm'])
+      assert(headers['Authorization'].include?("realm=\"#{expected_realm}\""))
+      assert(headers['Authorization'].include?("id=\"#{input['id']}\""))
+      assert(headers['Authorization'].include?("nonce=\"#{input['nonce']}\""))
+      expected_headers = input['signed_headers'].join(';')
+      assert(headers['Authorization'].include?("headers=\"#{expected_headers}\""))
+      assert(headers['Authorization'].include?("version=\"2.0\""))
+      assert(headers['Authorization'].include?("signature=\"#{expectations['message_signature']}\""))
+
+      # Prove that we can authenticate the request.
+      attributes = Acquia::HTTPHmac::Auth::parse_auth_header(expectations['authorization_header'])
+      auth_args = args.merge(attributes)
+      auth_args[:allowed_skew] = input['timestamp'] + 900
+      auth_args[:headers] = signed_headers
+      ret = mac.request_authenticated?(auth_args)
+      assert(ret, "request_authenticated? failed for #{input['name']}")
+    end
+
+  end
+
+end


### PR DESCRIPTION
Hello! Now that there are [shared test fixtures](https://github.com/acquia/http-hmac-spec/pull/18) in the spec repo, I'd like to use them here to ensure compatibility. They were generated using the golang implementation and the PHP v2 implementation will be using them to test. This will help ensure interoperability of messages signed by each of the languages.

In order to test the fixtures, I needed to be able to inject the expiration of the request, but there is still one of the original tests that ensures we expire after 900 seconds by default.
